### PR TITLE
Remove default value for URL Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Tested with **Snipe-IT v4.6.4** on **Ubuntu 16.04**.
 
 These properties are available in all resources:
 
-- `:token`, String
-- `:url`, String, default: `node['snipeit']['api']['instance']`
+- `:token`, String, required: true
+- `:url`, String, required: true
 
 ### `asset`
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Installs/Configures snipeit_api'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.2.0'
 chef_version '>= 14.0'
 source_url 'https://github.com/Microsoft/snipe-it-api-cookbook'
 issues_url 'https://github.com/Microsoft/snipe-it-api-cookbook/issues'

--- a/resources/asset.rb
+++ b/resources/asset.rb
@@ -10,7 +10,7 @@ property :serial_number, String, required: true
 property :status, String, required: true
 property :supplier, String
 property :token, String, required: true
-property :url, String, default: node['snipeit']['api']['instance']
+property :url, String, required: true
 
 default_action :create
 

--- a/resources/category.rb
+++ b/resources/category.rb
@@ -2,7 +2,7 @@ include SnipeIT::API
 
 resource_name :category
 
-property :url, String, default: node['snipeit']['api']['instance']
+property :url, String, required: true
 property :token, String, required: true
 property :category, String, name_property: true
 property :category_type, String, required: true

--- a/resources/location.rb
+++ b/resources/location.rb
@@ -2,7 +2,7 @@ include SnipeIT::API
 
 resource_name :location
 
-property :url, String, default: node['snipeit']['api']['instance']
+property :url, String, required: true
 property :token, String, required: true
 property :location, String, name_property: true
 property :address, String

--- a/resources/manufacturer.rb
+++ b/resources/manufacturer.rb
@@ -2,7 +2,7 @@ include SnipeIT::API
 
 resource_name :manufacturer
 
-property :url, String, default: node['snipeit']['api']['instance']
+property :url, String, required: true
 property :token, String, required: true
 property :manufacturer, String, name_property: true
 property :website, String

--- a/resources/model.rb
+++ b/resources/model.rb
@@ -2,7 +2,7 @@ include SnipeIT::API
 
 resource_name :model
 
-property :url, String, default: node['snipeit']['api']['instance']
+property :url, String, required: true
 property :token, String, required: true
 property :model, String, name_property: true
 property :model_number, String

--- a/spec/unit/resources/asset_spec.rb
+++ b/spec/unit/resources/asset_spec.rb
@@ -4,12 +4,14 @@ shared_examples 'asset' do
   step_into :asset
   recipe do
     api_token = chef_vault_item('snipe-it', 'api')['key']
+    url = node['snipeit']['api']['instance']
 
     asset '1234567' do
       serial_number 'W80123456789'
       status 'Pending'
       model 'Mac Pro (Early 2009)'
       token api_token
+      url url
     end
 
     asset '0000000' do
@@ -18,6 +20,7 @@ shared_examples 'asset' do
       model 'Mac Pro (Early 2009)'
       location 'Building 1'
       token api_token
+      url url
     end
   end
 end

--- a/spec/unit/resources/category_spec.rb
+++ b/spec/unit/resources/category_spec.rb
@@ -4,15 +4,18 @@ shared_examples 'category' do
   step_into :category
   recipe do
     api_token = node['snipeit']['api']['token']
+    url = 'http://fakeymcfakerton.corp.mycompany.com'
 
     category 'Desktop - macOS' do
       category_type 'asset'
       token api_token
+      url url
     end
 
     category 'Misc Software' do
       category_type 'license'
       token api_token
+      url url
     end
   end
 end

--- a/spec/unit/resources/location_spec.rb
+++ b/spec/unit/resources/location_spec.rb
@@ -4,6 +4,8 @@ shared_examples 'location' do
   step_into :location
   recipe do
     api_token = node['snipeit']['api']['token']
+    url = node['snipeit']['api']['instance']
+
     location 'Building 1' do
       address '16011 NE 36th Way'
       city 'Redmond'
@@ -11,6 +13,7 @@ shared_examples 'location' do
       zip '98052'
       currency 'USD'
       token api_token
+      url url
     end
 
     location 'Building 2' do
@@ -20,6 +23,7 @@ shared_examples 'location' do
       zip '98052'
       currency 'USD'
       token api_token
+      url url
     end
   end
 end

--- a/spec/unit/resources/manufacturer_spec.rb
+++ b/spec/unit/resources/manufacturer_spec.rb
@@ -6,10 +6,12 @@ shared_examples 'manufacturer' do
     manufacturer 'Apple' do
       website 'https://www.apple.com'
       token 'asdjlkhlskjha348298phluasf-.'
+      url 'http://fakeymcfakerton.corp.mycompany.com'
     end
 
     manufacturer 'Dell' do
       token 'asdjlkhlskjha348298phluasf-.'
+      url 'http://fakeymcfakerton.corp.mycompany.com'
     end
   end
 end

--- a/spec/unit/resources/model_spec.rb
+++ b/spec/unit/resources/model_spec.rb
@@ -4,12 +4,14 @@ shared_examples 'model' do
   step_into :model
   recipe do
     api_token = node['snipeit']['api']['token']
+    url = node['snipeit']['api']['instance']
 
     model 'Mac Pro (Early 2009)' do
       manufacturer 'Apple'
       category 'macOS - Desktop'
       model_number 'MacPro4,1'
       token api_token
+      url url
     end
 
     model 'HAL 9000' do
@@ -17,6 +19,7 @@ shared_examples 'model' do
       category 'Windows - Desktop'
       model_number 'HAL9000'
       token api_token
+      url url
     end
   end
 end

--- a/test/fixtures/cookbooks/snipeit_api_test/recipes/configure_snipeit.rb
+++ b/test/fixtures/cookbooks/snipeit_api_test/recipes/configure_snipeit.rb
@@ -4,16 +4,19 @@ categories = {
 }
 
 api_token = node['snipeit']['api']['token']
+url = node['snipeit']['api']['instance']
 
 manufacturer 'Apple' do
   website 'https://www.apple.com'
   token api_token
+  url url
 end
 
 categories.each do |name, type|
   category name do
     category_type type
     token api_token
+    url url
   end
 end
 
@@ -22,6 +25,7 @@ model 'Mac Pro (Early 2009)' do
   category 'macOS - Desktop'
   model_number 'MacPro4,1'
   token api_token
+  url url
 end
 
 asset '1234567' do
@@ -29,6 +33,7 @@ asset '1234567' do
   status 'Pending'
   model 'Mac Pro (Early 2009)'
   token api_token
+  url url
 end
 
 location 'Building 1' do
@@ -37,4 +42,5 @@ location 'Building 1' do
   state 'CA'
   zip '94130'
   token api_token
+  url url
 end


### PR DESCRIPTION
This prevents an issue with the `node['snipeit']['api']['instance']` attempting to be rendered even if you set the `url` property in a resource block.